### PR TITLE
qgis_maximum_version may be null

### DIFF
--- a/src/plugin/metadata_model.py
+++ b/src/plugin/metadata_model.py
@@ -74,7 +74,7 @@ class MetadataModel(Model):
     ended_at = UTCDateTimeAttribute(null=True)
     name = UnicodeAttribute(null=False)
     qgis_minimum_version = UnicodeAttribute(null=False)
-    qgis_maximum_version = UnicodeAttribute(null=False)
+    qgis_maximum_version = UnicodeAttribute(null=True)
     description = UnicodeAttribute(null=False)
     about = UnicodeAttribute(null=False)
     version = UnicodeAttribute(null=False)


### PR DESCRIPTION
qgis_maximum_version is not mandatory (https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/plugins/plugins.html#plugin-metadata) 