### PR TITLE
extraneous deployment code removed

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -28,22 +28,6 @@ provider:
         - dynamodb:DescribeTable
       Resource: "arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/${self:provider.environment.PLUGINS_TABLE_NAME}"
 
-
-components:
-  webFrontend:
-    type: static-website
-    inputs:
-      name: frontend
-      contentPath: ${self.path}/frontend
-      # templateValues:
-      #   apiUrl: ${productsApi.url}
-      contentIndex: index.html
-      contentError: index.html
-      hostingRegion: ${self:provider.region}
-      # hostingDomain: retail-${self.serviceId}.example.com
-      # aliasDomain: www.retail-${self.serviceId}.example.com
-
-
 custom:
   pythonRequirements:
    usePoetry: false


### PR DESCRIPTION
Extraneous code is a relic of exploring swagger hosting methods. 
It should not have made it to master under the swagger bundle approach decided on 