### PR TITLE
set default max_ver minor to .99

### DIFF
--- a/src/plugin/metadata_model.py
+++ b/src/plugin/metadata_model.py
@@ -204,7 +204,7 @@ class MetadataModel(Model):
             [
                 cls.qgis_maximum_version.set(
                     general_metadata.get(
-                        "qgisMaximumVersion", f"{general_metadata.get('qgisMinimumVersion').split('.')[0]}.999"
+                        "qgisMaximumVersion", f"{general_metadata.get('qgisMinimumVersion').split('.')[0]}.99"
                     )
                 ),
                 cls.revisions.set(version_zero.revisions + 1),


### PR DESCRIPTION
Setting the qgis_maximum_version minor to `.999` stop QGIS making those plugins available to QGIS users. This reverts it back to `.99`

This is inline with the [QGIS plugin issue wiki](https://issues.qgis.org/projects/qgis/wiki/Plugin_Compatibility) that states "Note '99' is the highest allowed value, please don't use higher numbers."
