### PR TITLE
chore: BSD to MIT licence

### DIFF
--- a/src/plugin/api.py
+++ b/src/plugin/api.py
@@ -1,12 +1,12 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
 

--- a/src/plugin/aws.py
+++ b/src/plugin/aws.py
@@ -1,16 +1,16 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
 
-    Database metadata manager
+    Interactions with repo's s3 data store
 
 """
 

--- a/src/plugin/error.py
+++ b/src/plugin/error.py
@@ -1,15 +1,17 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
+
     Custom Error class
+
 """
 
 from flask import jsonify

--- a/src/plugin/metadata_model.py
+++ b/src/plugin/metadata_model.py
@@ -1,18 +1,19 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
 
     Model for dynamoDB
 
 """
+
 # pylint: disable=too-few-public-methods
 
 

--- a/src/plugin/plugin_parser.py
+++ b/src/plugin/plugin_parser.py
@@ -1,15 +1,17 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
+
     For parsing plugin metadata
+
 """
 
 

--- a/src/plugin/plugin_xml.py
+++ b/src/plugin/plugin_xml.py
@@ -1,16 +1,18 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
-"""
 
+    Methods for generating QGIS xml
+
+"""
 
 import xml.etree.ElementTree as ET
 

--- a/src/plugin/swagger_ui.py
+++ b/src/plugin/swagger_ui.py
@@ -1,17 +1,14 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
-
-    Flask API for managing the storage and retrieval QGIS Plugins in S3
-
 """
 
 import json

--- a/src/plugin/swagger_ui/static/swagger.json
+++ b/src/plugin/swagger_ui/static/swagger.json
@@ -8,8 +8,8 @@
       "email": "splanzer@linz.govt.nz"
     },
     "license": {
-      "name": "BSD-3-Clause",
-      "url": "http://www.opensource.org/licenses/BSD-3-Clause"
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
     },
     "version": "1.0.0"
   },

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,12 +1,12 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
 """

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,12 +1,12 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
 """

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -1,14 +1,1 @@
-"""
-################################################################################
-#
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
-#
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
-#
-################################################################################
-"""
-
 # There are no tests for this module at this stage

--- a/tests/unit/test_metadata_model.py
+++ b/tests/unit/test_metadata_model.py
@@ -1,12 +1,12 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
 """

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -1,12 +1,12 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
 """

--- a/tests/unit/test_plugin_xml.py
+++ b/tests/unit/test_plugin_xml.py
@@ -1,12 +1,12 @@
 """
 ################################################################################
 #
-# Copyright 2019 Crown copyright (c)
-# Land Information New Zealand and the New Zealand Government.
-# All rights reserved
+#  LINZ QGIS plugin repository,
+#  Crown copyright (c) 2020, Land Information New Zealand on behalf of
+#  the New Zealand Government.
 #
-# This program is released under the terms of the 3 clause BSD license. See the
-# LICENSE file for more information.
+#  This file is released under the MIT licence. See the LICENCE file found
+#  in the top-level directory of this distribution for more information.
 #
 ################################################################################
 """


### PR DESCRIPTION
Licence changed to MIT as per NZ govt instruction on opensource software