### PR TITLE
fix: Use new environment variable syntax

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -80,7 +80,7 @@ jobs:
         run: npx serverless deploy --stage dev --resource-suffix ${{ secrets.DEPLOYMENT_SUFFIX_DEV }}
 
       - name: get deployment url
-        run: echo ::set-env name=BASE_URL::$(npx serverless info | grep -o 'https.*\/dev\/')
+        run: echo BASE_URL=$(npx serverless info | grep -o 'https.*\/dev\/') >> "$GITHUB_ENV"
 
       - name: Test (sys)
         run: BASE_URL=${{ env.BASE_URL }} pytest tests/sys/


### PR DESCRIPTION
As per GitHub job output:

> Error: Unable to process command '::set-env
> name=BASE_URL::https://j4osj0imtb.execute-api.ap-southeast-2.amazonaws.com/dev/'
> successfully.

> Error: The `set-env` command is disabled. Please upgrade to using
> Environment Files or opt into unsecure command execution by setting the
> `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For
> more information see:
> https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/